### PR TITLE
error de nombre de rubro

### DIFF
--- a/src/app/pages/plan-cuentas/cdp/ver-solicitud-cdp/ver-solicitud-cdp.component.html
+++ b/src/app/pages/plan-cuentas/cdp/ver-solicitud-cdp/ver-solicitud-cdp.component.html
@@ -57,7 +57,7 @@
                     </thead>
                     <tbody>
                         <tr>
-                            <td>{{rubro.RubroId}} {{rubro.InfoRubro.Nombre}}</td>
+                            <td>{{rubro.RubroId}} </td>
                             <td class="moneyField">{{rubro.MontoParcial | currency: COP }}</td>
                             <!-- TODO calcular valor rubro -->
                         </tr>


### PR DESCRIPTION
se quita esta parte ya que el objeto desde el mid no esta enviado la información completa de la necesidad y se rompe el cliente