### PR TITLE
Feat/ajuste creacion arbol rubros y apropiacion

### DIFF
--- a/src/app/@core/helpers/arbol/arbolHelper.ts
+++ b/src/app/@core/helpers/arbol/arbolHelper.ts
@@ -23,6 +23,35 @@ export class ArbolHelper {
         // call request manager for the tree's data.
         return this.rqManager.get(`arbol_rubro_apropiacion/arbol_apropiacion_valores/${unidadEjecutora}/${vigencia}`);
     }
+    /**
+      * Gets full arbol
+      *  returns full rubro's tree information (all nodes and branches).
+      * @returns  data with tree structure for the ndTree module.
+      */
+    public getFullArbolbyID(vigencia = '0', id: string , level = '-1') {
+        this.rqManager.setPath('PLAN_CUENTAS_MONGO_SERVICE');
+        // this.rqManager.setPath('DUMMY_SERVICE');
+        // Set the optional branch for the API request.
+        const unidadEjecutora = 1;
+        // const raiz = 3;
+        // call request manager for the tree's data.
+        return this.rqManager.get(`arbol_rubro_apropiacion/arbol_apropiacion_valores/${unidadEjecutora}/${vigencia}/${id}?nivel=${level}`);
+    }
+
+    /**
+      * Gets full nodo
+      *  returns full rubro's tree information (all nodes and branches).
+      * @returns  data with tree structure for the ndTree module.
+      */
+    public getFullNodobyID(vigencia = '0', id: string , level = '0') {
+        this.rqManager.setPath('PLAN_CUENTAS_MID_SERVICE');
+        // this.rqManager.setPath('DUMMY_SERVICE');
+        // Set the optional branch for the API request.
+        const unidadEjecutora = 1;
+        // const raiz = 3;
+        // call request manager for the tree's data.
+        return this.rqManager.get(`apropiacion/ArbolRubroApropiacion/${unidadEjecutora}/${vigencia}/${id}?nivel=${level}`);
+    }
 
     /**
       * Gets full arbol by Estado

--- a/src/app/@core/helpers/rubros/rubroHelper.ts
+++ b/src/app/@core/helpers/rubros/rubroHelper.ts
@@ -29,6 +29,26 @@ export class RubroHelper {
         return this.rqManager.get(`arbol_rubro/arbol/${branch}`, params);
 
     }
+    /**
+     * Gets arbol reducido
+     *  returns one tree level at once.
+     * @param [branch] tree's branch to request info from the API
+     * @param [level] tree's level to request info from the API
+     * @returns  branch information.
+     */
+    public getArbolReducido(branch?: string, level?: string) {
+        this.rqManager.setPath('PLAN_CUENTAS_MONGO_SERVICE');
+        // this.rqManager.setPath('DUMMY_SERVICE');
+        // Set the optional branch for the API request.
+        // const unidadEjecutora = 1;
+        const params = {
+            rama: branch,
+            nivel: level,
+        };
+        // call request manager for the tree's data.
+        return this.rqManager.get(`arbol_rubro/arbol_reducido/${branch}?nivel=${level}`, params);
+
+    }
 
 
     public getRubro(codigo: string) {

--- a/src/app/pages/plan-cuentas/arbol/arbol.component.html
+++ b/src/app/pages/plan-cuentas/arbol/arbol.component.html
@@ -1,10 +1,15 @@
 <nb-card *ngIf="opcionSeleccionada=='Rubros'">
+    <nb-card [nbSpinner]="loading" nbSpinnerSize="tiny" nbSpinnerStatus="primary">
+      <nb-card-body *ngIf="loading">
+        Cargando arbol rubros (Por favor espere unos minutos).
+      </nb-card-body>
+    </nb-card>
   <nb-card-body>
     <label class="search-label" for="search">{{
       "GLOBAL.buscar" | translate
     }}</label>
     <input nbInput [nbFilterInput]="dataSource" id="search" class="search-input" [(ngModel)]="searchValue"  />
-    <table  [nbTreeGrid]="dataSource" [nbSort]="dataSource" (sort)="updateSort($event)" [nbSpinner]="loading" nbSpinnerStatus="primary">
+    <table  [nbTreeGrid]="dataSource" [nbSort]="dataSource" (sort)="updateSort($event)" >
       <tr nbTreeGridHeaderRow *nbTreeGridHeaderRowDef="allColumns"></tr>
       <tr #nebularTree class="table-row" [class.highlight]="validHighlight(row, nebularTree)" (click)="onSelect(row, nebularTree);" nbTreeGridRow *nbTreeGridRowDef="let row; columns: allColumns" [attr.data-picker]="row.data.Codigo"></tr>
       <ng-container [nbTreeGridColumnDef]="customColumn" >
@@ -34,6 +39,11 @@
 </nb-card>
 <!-- ArbolApropiaciones -->
 <nb-card *ngIf="opcionSeleccionada=='Apropiaciones' || opcionSeleccionada=='ApropiacionesEstado' ">
+  <nb-card [nbSpinner]="loading" nbSpinnerSize="tiny" nbSpinnerStatus="primary">
+    <nb-card-body *ngIf="loading">
+      Cargando arbol apropiación (Por favor espere unos minutos).
+    </nb-card-body>
+  </nb-card>
   <nb-card-body>
     <!-- Buscador -->
     <label class="search-label" for="search">{{
@@ -41,9 +51,9 @@
     }}</label>
     <input nbInput [nbFilterInput]="dataSource2" id="search" class="search-input" [(ngModel)]="searchValue" />
     <!-- Tabla ArbolApropiaciones -->
-    <table [nbTreeGrid]="dataSource2" [nbSort]="dataSource2" (sort)="updateSort($event)" [nbSpinner]="loading" nbSpinnerStatus="primary">
+    <table [nbTreeGrid]="dataSource2" [nbSort]="dataSource2" (sort)="updateSort($event)">
       <tr nbTreeGridHeaderRow *nbTreeGridHeaderRowDef="allColumns"></tr>
-      <tr #nebularTree class="table-row" [class.highlight]="validHighlight(row, nebularTree)" (click)="onSelect(row, nebularTree);" nbTreeGridRow *nbTreeGridRowDef="let row; columns: allColumns" [attr.data-picker]="row.data.Codigo"></tr>
+      <tr #nebularTree class="table-row" [class.highlight]="validHighlight(row, nebularTree)" (click)="onSelect(row, nebularTree); " nbTreeGridRow *nbTreeGridRowDef="let row; columns: allColumns" [attr.data-picker]="row.data.Codigo" ></tr>
       <ng-container [nbTreeGridColumnDef]="customColumn">
         <th nbTreeGridHeaderCell [nbSortHeader]="getSortDirection(customColumn)" *nbTreeGridHeaderCellDef>
           {{ customColumn | translate }}

--- a/src/app/pages/plan-cuentas/arbol/arbol.component.ts
+++ b/src/app/pages/plan-cuentas/arbol/arbol.component.ts
@@ -14,8 +14,6 @@ import { registerLocaleData } from '@angular/common';
 
 import locales from '@angular/common/locales/es-CO';
 import { zip } from 'rxjs';
-import { of } from 'rxjs';
-import { mergeMap } from 'rxjs/operators';
 
 registerLocaleData(locales, 'co');
 
@@ -109,7 +107,7 @@ export class ArbolComponent implements OnChanges {
   // private data: TreeNode<EstructuraArbolRubrosApropiaciones>[] | TreeNode<EstructuraArbolRubros>[];
 
   private data: EstructuraArbolRubrosApropiaciones[];
-  private data2: EstructuraArbolRubrosApropiaciones[];
+  // private data2: EstructuraArbolRubrosApropiaciones[];
   private reduceData: EstructuraArbolRubrosApropiaciones[];
   loadTreeRubros() {
     const getters: NbGetters<EstructuraArbolRubrosApropiaciones, EstructuraArbolRubrosApropiaciones> = {
@@ -120,28 +118,28 @@ export class ArbolComponent implements OnChanges {
 
     forkJoin(
       {
-        root_2: this.rubroHelper.getArbolReducido('2','2'),
-        root_3: this.rubroHelper.getArbolReducido('3','2'),
+        root_2: this.rubroHelper.getArbolReducido('2', '2'),
+        root_3: this.rubroHelper.getArbolReducido('3', '2'),
       }
     ).
     subscribe((res) => {
 
-      let hijos_2  = this.consultarHijos(res.root_2,"2")
-      let hijos_3  = this.consultarHijos(res.root_3,"2")
-      let hijos = hijos_2.concat(hijos_3)
-      let obs: any[] =[]
-      for( let hijo of hijos){
-        obs.push(this.rubroHelper.getArbolReducido(hijo,"-1"))
+      const hijos_2  = this.consultarHijos(res.root_2, '2');
+      const hijos_3  = this.consultarHijos(res.root_3, '2');
+      const hijos = hijos_2.concat(hijos_3);
+      const obs: any[] = [];
+      for ( const hijo of hijos) {
+        obs.push(this.rubroHelper.getArbolReducido(hijo, '-1'));
       }
       zip(...obs).subscribe((resHijos) => {
-        res.root_2 = this.reconstruirArbol(res.root_2, resHijos, "2")
-        res.root_3 = this.reconstruirArbol(res.root_3, resHijos.slice(hijos_2.length,hijos_2.length+hijos_3.length), "2")
+        res.root_2 = this.reconstruirArbol(res.root_2, resHijos, '2');
+        res.root_3 = this.reconstruirArbol(res.root_3, resHijos.slice(hijos_2.length, hijos_2.length + hijos_3.length), '2');
 
         this.reduceData = res.root_2.concat(res.root_3);
         this.dataSource = this.dataSourceBuilder.create(this.reduceData, getters);
         this.loadedTreeRubros();
 
-      })
+      });
 
     });
   }
@@ -164,106 +162,106 @@ export class ArbolComponent implements OnChanges {
     if (this.vigenciaSeleccionada) {
       forkJoin(
         {
-          raiz_2: this.treeHelper.getFullArbolbyID(this.vigenciaSeleccionada,"2","2"),
-          raiz_3: this.treeHelper.getFullArbolbyID(this.vigenciaSeleccionada,"3","2"),
-          raiz_4: this.treeHelper.getFullArbolbyID(this.vigenciaSeleccionada,"2-00-991-00","1"),
-          raiz_5: this.treeHelper.getFullArbolbyID(this.vigenciaSeleccionada,"3-00-991-00","1"),
-          raiz_6: this.treeHelper.getFullNodobyID(this.vigenciaSeleccionada,"2-00-991-00-00-29","0"),
-          raiz_7: this.treeHelper.getFullNodobyID(this.vigenciaSeleccionada,"3-00-991-00-00-29","0"),
+          raiz_2: this.treeHelper.getFullArbolbyID(this.vigenciaSeleccionada, '2', '2'),
+          raiz_3: this.treeHelper.getFullArbolbyID(this.vigenciaSeleccionada, '3', '2'),
+          raiz_4: this.treeHelper.getFullArbolbyID(this.vigenciaSeleccionada, '2-00-991-00', '1'),
+          raiz_5: this.treeHelper.getFullArbolbyID(this.vigenciaSeleccionada, '3-00-991-00', '1'),
+          raiz_6: this.treeHelper.getFullNodobyID(this.vigenciaSeleccionada, '2-00-991-00-00-29', '0'),
+          raiz_7: this.treeHelper.getFullNodobyID(this.vigenciaSeleccionada, '3-00-991-00-00-29', '0'),
 
         }
       ).
       subscribe((res) => {
 
-        let hijos_2  = this.consultarHijos(res.raiz_2,"2")
-        hijos_2[0] = "2-01-001-02" //evita consultar la raiz 2-00-991-00 ya que se realiza aparte
-        let hijos_3  = this.consultarHijos(res.raiz_3,"2")
-        hijos_3[0] = "3-01-001-01" //evita consultar la raiz 3-00-991-00 ya que se realiza aparte
-        let hijos_2_1  = this.consultarHijos(res.raiz_4,"1")
-        hijos_2_1[4] = "2-00-991-00-00-00" //evita consultar la raiz 2-00-991-00-00-29 ya que se realiza aparte
-        let hijos_3_1  = this.consultarHijos(res.raiz_5,"1")
-        hijos_3_1[3] = "3-00-991-00-00-01" //evita consultar la raiz 3-00-991-00-00-29 ya que se realiza aparte
-        let hijos = hijos_2.concat(hijos_3, hijos_2_1, hijos_3_1)
-        let obs: any[] =[]
-        for( let hijo of hijos){
-          obs.push(this.treeHelper.getFullArbolbyID(this.vigenciaSeleccionada,hijo,"-1"))
+        const hijos_2  = this.consultarHijos(res.raiz_2, '2');
+        hijos_2[0] = '2-01-001-02'; // evita consultar la raiz 2-00-991-00 ya que se realiza aparte
+        const hijos_3  = this.consultarHijos(res.raiz_3, '2');
+        hijos_3[0] = '3-01-001-01'; // evita consultar la raiz 3-00-991-00 ya que se realiza aparte
+        const hijos_2_1  = this.consultarHijos(res.raiz_4, '1');
+        hijos_2_1[4] = '2-00-991-00-00-00'; // evita consultar la raiz 2-00-991-00-00-29 ya que se realiza aparte
+        const hijos_3_1  = this.consultarHijos(res.raiz_5, '1');
+        hijos_3_1[3] = '3-00-991-00-00-01'; // evita consultar la raiz 3-00-991-00-00-29 ya que se realiza aparte
+        const hijos = hijos_2.concat(hijos_3, hijos_2_1, hijos_3_1);
+        const obs: any[] = [];
+        for ( const hijo of hijos) {
+          obs.push(this.treeHelper.getFullArbolbyID(this.vigenciaSeleccionada, hijo, '-1'));
         }
         zip(...obs).subscribe((resHijos) => {
-          res.raiz_2 = this.reconstruirArbol(res.raiz_2, resHijos, "2")
-          res.raiz_3 = this.reconstruirArbol(res.raiz_3, resHijos.slice(hijos_2.length,hijos_2.length+hijos_3.length), "2")
-          res.raiz_4 = this.reconstruirArbol(res.raiz_4, resHijos.slice(hijos_2.length+hijos_3.length,hijos_2.length+hijos_3.length+hijos_2_1.length),"1")
-          res.raiz_5 = this.reconstruirArbol(res.raiz_5, resHijos.slice(hijos_2.length+hijos_3.length+hijos_2_1.length,),"1")
+          res.raiz_2 = this.reconstruirArbol(res.raiz_2, resHijos, '2');
+          res.raiz_3 = this.reconstruirArbol(res.raiz_3, resHijos.slice(hijos_2.length, hijos_2.length + hijos_3.length), '2');
+          res.raiz_4 = this.reconstruirArbol(res.raiz_4, resHijos.slice(hijos_2.length + hijos_3.length, hijos_2.length + hijos_3.length + hijos_2_1.length), '1');
+          res.raiz_5 = this.reconstruirArbol(res.raiz_5, resHijos.slice(hijos_2.length + hijos_3.length + hijos_2_1.length, ), '1');
 
 
-          res.raiz_4[0].children[0].children[4]= res.raiz_6[0]
-          res.raiz_5[0].children[0].children[3]= res.raiz_7[0]
+          res.raiz_4[0].children[0].children[4] = res.raiz_6[0];
+          res.raiz_5[0].children[0].children[3] = res.raiz_7[0];
 
-          let childrenData2 = { children : []}
-          childrenData2.children = childrenData2.children.concat(res.raiz_4)
-          res.raiz_2[0].children[0].children[0].children[0]= Object.assign(res.raiz_2[0].children[0].children[0], childrenData2)
+          const childrenData2 = { children : []};
+          childrenData2.children = childrenData2.children.concat(res.raiz_4);
+          res.raiz_2[0].children[0].children[0].children[0] = Object.assign(res.raiz_2[0].children[0].children[0], childrenData2);
 
-          let childrenData3 = { children : []}
-          childrenData3.children = childrenData3.children.concat(res.raiz_5)
-          res.raiz_3[0].children[0].children[0].children[0]= Object.assign(res.raiz_3[0].children[0].children[0], childrenData3)
+          const childrenData3 = { children : []};
+          childrenData3.children = childrenData3.children.concat(res.raiz_5);
+          res.raiz_3[0].children[0].children[0].children[0] = Object.assign(res.raiz_3[0].children[0].children[0], childrenData3);
 
           this.data = res.raiz_2.concat(res.raiz_3);
           this.dataSource2 = this.dataSourceBuilder2.create(this.data, getters);
           this.loadedTreeRubros();
-        })
+        });
       });
     }
   }
 
-  reconstruirArbol(raiz : any , hijos : any, nivel: string){
-    if(nivel=="2"){
-      var contador : number = 0
+  reconstruirArbol(raiz: any , hijos: any, nivel: string) {
+    if (nivel === '2') {
+      let contador: number = 0;
       raiz[0].children.forEach((element, index)  => {
         raiz[0].children[index].children.forEach((element2, index2)  => {
-          var childrenData2 = { children : []}
+          const childrenData2 = { children : []};
           raiz[0].children[index].children[index2].Hijos.forEach((element3, index3) => {
-            childrenData2.children = childrenData2.children.concat(hijos[contador])
-            raiz[0].children[index].children[index2]= Object.assign(raiz[0].children[index].children[index2], childrenData2)
-            contador += 1
+            childrenData2.children = childrenData2.children.concat(hijos[contador]);
+            raiz[0].children[index].children[index2] = Object.assign(raiz[0].children[index].children[index2], childrenData2);
+            contador += 1;
          });
         });
       });
-      return raiz
-    }else{
-      var contador : number = 0
+      return raiz;
+    } else {
+      let contador: number = 0;
       raiz[0].children.forEach((element, index)  => {
-        var childrenData2 = { children : []}
+        const childrenData2 = { children : []};
         raiz[0].children[index].Hijos.forEach((element2, index2)  => {
-            childrenData2.children = childrenData2.children.concat(hijos[contador])
-            raiz[0].children[index]= Object.assign(raiz[0].children[index], childrenData2)
-            contador += 1
+            childrenData2.children = childrenData2.children.concat(hijos[contador]);
+            raiz[0].children[index] = Object.assign(raiz[0].children[index], childrenData2);
+            contador += 1;
 
         });
       });
-      return raiz
+      return raiz;
     }
 
   }
 
-  consultarHijos(raiz : any, nivel : string)  {
-    
-    if(nivel == "2"){
-      let hijos :string[] = [] 
+  consultarHijos(raiz: any, nivel: string)  {
+
+    if (nivel === '2') {
+      const hijos: string[] = [];
       raiz[0].children.forEach((element, index)  => {
          raiz[0].children[index].children.forEach((element2, index2)  => {
            raiz[0].children[index].children[index2].Hijos.forEach((element3, index3) => {
-            hijos.push(element3)
+            hijos.push(element3);
           });
          });
       });
-      return hijos
-    }else{
-      let hijos :string[] = [] 
+      return hijos;
+    } else {
+      const hijos: string[] = [];
       raiz[0].children.forEach((element, index)  => {
          raiz[0].children[index].Hijos.forEach((element2, index2)  => {
-            hijos.push(element2)
+            hijos.push(element2);
          });
       });
-      return hijos
+      return hijos;
     }
 
   }
@@ -313,7 +311,7 @@ export class ArbolComponent implements OnChanges {
   }
 
   async onSelect(selectedItem: any, treegrid) {
-    
+
     this.idHighlight = treegrid.elementRef.nativeElement.getAttribute('data-picker');
     this.rubroSeleccionado.emit(selectedItem.data);
   }

--- a/src/app/pages/plan-cuentas/arbol/arbol.component.ts
+++ b/src/app/pages/plan-cuentas/arbol/arbol.component.ts
@@ -11,7 +11,11 @@ import { Observable, forkJoin } from 'rxjs';
 import { ArbolHelper } from '../../../@core/helpers/arbol/arbolHelper';
 import { RubroHelper } from '../../../@core/helpers/rubros/rubroHelper';
 import { registerLocaleData } from '@angular/common';
+
 import locales from '@angular/common/locales/es-CO';
+import { zip } from 'rxjs';
+import { of } from 'rxjs';
+import { mergeMap } from 'rxjs/operators';
 
 registerLocaleData(locales, 'co');
 
@@ -30,6 +34,8 @@ interface EstructuraArbolRubrosApropiaciones {
   data?: EstructuraArbolRubrosApropiaciones;
   children?: EstructuraArbolRubrosApropiaciones[];
 }
+
+
 
 @Component({
   selector: 'ngx-arbol',
@@ -62,6 +68,7 @@ export class ArbolComponent implements OnChanges {
   idHighlight: any;
   isSelected: boolean;
   searchValue: string;
+  nodo: any;
 
   loading = true;
 
@@ -102,22 +109,40 @@ export class ArbolComponent implements OnChanges {
   // private data: TreeNode<EstructuraArbolRubrosApropiaciones>[] | TreeNode<EstructuraArbolRubros>[];
 
   private data: EstructuraArbolRubrosApropiaciones[];
+  private data2: EstructuraArbolRubrosApropiaciones[];
+  private reduceData: EstructuraArbolRubrosApropiaciones[];
   loadTreeRubros() {
     const getters: NbGetters<EstructuraArbolRubrosApropiaciones, EstructuraArbolRubrosApropiaciones> = {
-      dataGetter: (node: EstructuraArbolRubrosApropiaciones) => node.data || null,
-      childrenGetter: (node: EstructuraArbolRubrosApropiaciones) => !!node.children && !!node.children.length ? node.children : [],
-      expandedGetter: (node: EstructuraArbolRubrosApropiaciones) => !!node.expanded,
+      dataGetter: (node: EstructuraArbolRubrosApropiaciones) => node.data || null ,
+      childrenGetter: (node: EstructuraArbolRubrosApropiaciones) => !!node.children && !!node.children.length  ?  node.children : [] ,
+      expandedGetter: (node: EstructuraArbolRubrosApropiaciones) => !!node.expanded ,
     };
+
     forkJoin(
       {
-        root_2: this.rubroHelper.getArbol('2'),
-        root_3: this.rubroHelper.getArbol('3'),
+        root_2: this.rubroHelper.getArbolReducido('2','2'),
+        root_3: this.rubroHelper.getArbolReducido('3','2'),
       }
     ).
     subscribe((res) => {
-      this.data = res.root_2.concat(res.root_3);
-      this.dataSource = this.dataSourceBuilder.create(this.data, getters);
-      this.loadedTreeRubros();
+
+      let hijos_2  = this.consultarHijos(res.root_2,"2")
+      let hijos_3  = this.consultarHijos(res.root_3,"2")
+      let hijos = hijos_2.concat(hijos_3)
+      let obs: any[] =[]
+      for( let hijo of hijos){
+        obs.push(this.rubroHelper.getArbolReducido(hijo,"-1"))
+      }
+      zip(...obs).subscribe((resHijos) => {
+        res.root_2 = this.reconstruirArbol(res.root_2, resHijos, "2")
+        res.root_3 = this.reconstruirArbol(res.root_3, resHijos.slice(hijos_2.length,hijos_2.length+hijos_3.length), "2")
+
+        this.reduceData = res.root_2.concat(res.root_3);
+        this.dataSource = this.dataSourceBuilder.create(this.reduceData, getters);
+        this.loadedTreeRubros();
+
+      })
+
     });
   }
 
@@ -135,14 +160,112 @@ export class ArbolComponent implements OnChanges {
     this.customColumn = 'Codigo';
     this.defaultColumns = ['Nombre', 'ValorInicial'];
     this.allColumns = [this.customColumn, ...this.defaultColumns];
+
     if (this.vigenciaSeleccionada) {
-      this.treeHelper.getFullArbol(this.vigenciaSeleccionada).subscribe(res => {
-        this.data = res;
-        this.dataSource2 = this.dataSourceBuilder2.create(this.data, getters);
-        this.loadedTreeRubros();
-      },
-      );
+      forkJoin(
+        {
+          raiz_2: this.treeHelper.getFullArbolbyID(this.vigenciaSeleccionada,"2","2"),
+          raiz_3: this.treeHelper.getFullArbolbyID(this.vigenciaSeleccionada,"3","2"),
+          raiz_4: this.treeHelper.getFullArbolbyID(this.vigenciaSeleccionada,"2-00-991-00","1"),
+          raiz_5: this.treeHelper.getFullArbolbyID(this.vigenciaSeleccionada,"3-00-991-00","1"),
+          raiz_6: this.treeHelper.getFullNodobyID(this.vigenciaSeleccionada,"2-00-991-00-00-29","0"),
+          raiz_7: this.treeHelper.getFullNodobyID(this.vigenciaSeleccionada,"3-00-991-00-00-29","0"),
+
+        }
+      ).
+      subscribe((res) => {
+
+        let hijos_2  = this.consultarHijos(res.raiz_2,"2")
+        hijos_2[0] = "2-01-001-02" //evita consultar la raiz 2-00-991-00 ya que se realiza aparte
+        let hijos_3  = this.consultarHijos(res.raiz_3,"2")
+        hijos_3[0] = "3-01-001-01" //evita consultar la raiz 3-00-991-00 ya que se realiza aparte
+        let hijos_2_1  = this.consultarHijos(res.raiz_4,"1")
+        hijos_2_1[4] = "2-00-991-00-00-00" //evita consultar la raiz 2-00-991-00-00-29 ya que se realiza aparte
+        let hijos_3_1  = this.consultarHijos(res.raiz_5,"1")
+        hijos_3_1[3] = "3-00-991-00-00-01" //evita consultar la raiz 3-00-991-00-00-29 ya que se realiza aparte
+        let hijos = hijos_2.concat(hijos_3, hijos_2_1, hijos_3_1)
+        let obs: any[] =[]
+        for( let hijo of hijos){
+          obs.push(this.treeHelper.getFullArbolbyID(this.vigenciaSeleccionada,hijo,"-1"))
+        }
+        zip(...obs).subscribe((resHijos) => {
+          res.raiz_2 = this.reconstruirArbol(res.raiz_2, resHijos, "2")
+          res.raiz_3 = this.reconstruirArbol(res.raiz_3, resHijos.slice(hijos_2.length,hijos_2.length+hijos_3.length), "2")
+          res.raiz_4 = this.reconstruirArbol(res.raiz_4, resHijos.slice(hijos_2.length+hijos_3.length,hijos_2.length+hijos_3.length+hijos_2_1.length),"1")
+          res.raiz_5 = this.reconstruirArbol(res.raiz_5, resHijos.slice(hijos_2.length+hijos_3.length+hijos_2_1.length,),"1")
+
+
+          res.raiz_4[0].children[0].children[4]= res.raiz_6[0]
+          res.raiz_5[0].children[0].children[3]= res.raiz_7[0]
+
+          let childrenData2 = { children : []}
+          childrenData2.children = childrenData2.children.concat(res.raiz_4)
+          res.raiz_2[0].children[0].children[0].children[0]= Object.assign(res.raiz_2[0].children[0].children[0], childrenData2)
+
+          let childrenData3 = { children : []}
+          childrenData3.children = childrenData3.children.concat(res.raiz_5)
+          res.raiz_3[0].children[0].children[0].children[0]= Object.assign(res.raiz_3[0].children[0].children[0], childrenData3)
+
+          this.data = res.raiz_2.concat(res.raiz_3);
+          this.dataSource2 = this.dataSourceBuilder2.create(this.data, getters);
+          this.loadedTreeRubros();
+        })
+      });
     }
+  }
+
+  reconstruirArbol(raiz : any , hijos : any, nivel: string){
+    if(nivel=="2"){
+      var contador : number = 0
+      raiz[0].children.forEach((element, index)  => {
+        raiz[0].children[index].children.forEach((element2, index2)  => {
+          var childrenData2 = { children : []}
+          raiz[0].children[index].children[index2].Hijos.forEach((element3, index3) => {
+            childrenData2.children = childrenData2.children.concat(hijos[contador])
+            raiz[0].children[index].children[index2]= Object.assign(raiz[0].children[index].children[index2], childrenData2)
+            contador += 1
+         });
+        });
+      });
+      return raiz
+    }else{
+      var contador : number = 0
+      raiz[0].children.forEach((element, index)  => {
+        var childrenData2 = { children : []}
+        raiz[0].children[index].Hijos.forEach((element2, index2)  => {
+            childrenData2.children = childrenData2.children.concat(hijos[contador])
+            raiz[0].children[index]= Object.assign(raiz[0].children[index], childrenData2)
+            contador += 1
+
+        });
+      });
+      return raiz
+    }
+
+  }
+
+  consultarHijos(raiz : any, nivel : string)  {
+    
+    if(nivel == "2"){
+      let hijos :string[] = [] 
+      raiz[0].children.forEach((element, index)  => {
+         raiz[0].children[index].children.forEach((element2, index2)  => {
+           raiz[0].children[index].children[index2].Hijos.forEach((element3, index3) => {
+            hijos.push(element3)
+          });
+         });
+      });
+      return hijos
+    }else{
+      let hijos :string[] = [] 
+      raiz[0].children.forEach((element, index)  => {
+         raiz[0].children[index].Hijos.forEach((element2, index2)  => {
+            hijos.push(element2)
+         });
+      });
+      return hijos
+    }
+
   }
 
   loadTreeApropiacionesEstado() {
@@ -190,6 +313,7 @@ export class ArbolComponent implements OnChanges {
   }
 
   async onSelect(selectedItem: any, treegrid) {
+    
     this.idHighlight = treegrid.elementRef.nativeElement.getAttribute('data-picker');
     this.rubroSeleccionado.emit(selectedItem.data);
   }


### PR DESCRIPTION
Se realizan los ajusten para que el cliente pueda cargar los árbol de rubro y árbol de apropiación.

Para el árbol se logro que se carguen ambas raíces en menos de 50s,  Tener en cuenta que este árbol se carga con el Enpoint de arbol reudcido que trae menor cantidad de datos.
![arbol_reducido](https://user-images.githubusercontent.com/34488581/107809419-0fc40480-6d39-11eb-97af-6cc9ddb99563.PNG)

Este árbol se carga con la consulta en paralelo de los hijos de las raíces desde el nivel dos, evitando que se tengan consultas de mas de un minuto, las raíces  3-00-991-00-00-29 y 2-00-991-00-00-29 son consultadas en plan_cuentas_mid, dado que era imposible su consulta porque tenían más de 500 hijos, para restas dos raíces se creo un EndPoint que se menciona más abajo.

El arbol aunque carga se demora entre 4-5minutos en cargar, por esto se agrego un spinner con un mensaje indicando que la consulta toma algunos minutos.
 
![arbol_presupuestal](https://user-images.githubusercontent.com/34488581/107809417-0f2b6e00-6d39-11eb-84ad-034977bf9068.PNG)


Debido a que dos raices en especifico presentaba problema para cargarla desde el cliente, fue necesario hacer las peticiones de dichas ramas desde el MID (ver el siguiente pull request relacionado https://github.com/udistrital/plan_cuentas_mid/pull/159) ,  dado que fue necesario el uso del MID fue necesario trabajar con VPN por lo que es posible que los tiempos una vez subidas las apis mejoren.

